### PR TITLE
Prevent untested files from being run by istanbul.

### DIFF
--- a/lib/run-cover.js
+++ b/lib/run-cover.js
@@ -11,7 +11,8 @@ var path = require('path'),
     libCoverage = require('istanbul-lib-coverage'),
     libSourceMaps = require('istanbul-lib-source-maps'),
     hook = require('istanbul-lib-hook'),
-    Reporter = require('./reporter');
+    Reporter = require('./reporter'),
+    Module = require('module');
 
 function getCoverFunctions(config, includes, callback) {
 
@@ -117,6 +118,17 @@ function getCoverFunctions(config, includes, callback) {
                 }
             });
             if (missingFiles.length > 0) {
+                var originalLoaders = Module._extensions;
+                Module._extensions = {};
+                Object.keys(originalLoaders).forEach(function(extention) {
+                  Module._extensions[extention] = function(module, filename) {
+                    module._compile = function (code, filename) {
+                      // Don't actually return the output, this prevents the file from being run.
+                      cov[filename] = instrumenter.lastFileCoverage().data;
+                    };
+                    originalLoaders[extention](module, filename);
+                  };
+                });
                 finalCoverage = clone(cov);
                 missingFiles.forEach(function (file) {
                     try {
@@ -133,6 +145,7 @@ function getCoverFunctions(config, includes, callback) {
                         finalCoverage[file] = fc.toJSON();
                     }
                 });
+                Module._extensions = originalLoaders;
             }
         }
         if (Object.keys(finalCoverage).length >0) {
@@ -194,4 +207,3 @@ function getCoverFunctions(config, includes, callback) {
 module.exports = {
     getCoverFunctions: getCoverFunctions
 };
-


### PR DESCRIPTION
This addresses the [issue](https://github.com/istanbuljs/istanbul-lib-hook/issues/6) that I opened in istanbul-lib-hook without using `process.env` which keeps istanbul specific logic out of that repo.
