### PR TITLE
Capture source maps when creating reports, if the --compilers option is specified

### DIFF
--- a/lib/run-reports.js
+++ b/lib/run-reports.js
@@ -24,7 +24,7 @@ function run(formats, config, opts, callback) {
         instOpts = config.instrumentation.getInstrumenterOpts(),
         includePattern = opts.include || '**/coverage*.raw.json',
         reporter = new Reporter(config),
-        transform,
+        transformer,
         compiledExtensions = [];
 
     instOpts.sourceMapUrlCallback = function (file, url) {
@@ -35,12 +35,12 @@ function run(formats, config, opts, callback) {
         return instrumenter.instrumentSync(code, file);
     };
     opts.compilers.forEach(function (c) {
-        var compiler = c.split(':')
-            , ext = compiler[0]
-            , mod = compiler[1];
+        var compiler = c.split(':'),
+            ext = compiler[0],
+            mod = compiler[1];
 
-        if (mod[0] == '.') {
-            mod = join(process.cwd(), mod);
+        if (mod[0] === '.') {
+            mod = path.join(process.cwd(), mod);
         }
         compiledExtensions.push(ext);
         require(mod);
@@ -81,7 +81,9 @@ function run(formats, config, opts, callback) {
         });
         if (compiledExtensions.length) {
             for (var filepath in coverageMap.data) {
-                require(filepath);
+                if (coverageMap.data.hasOwnProperty(filepath)) {
+                    require(filepath);
+                }
             }
         }
         var transformed = sourceMapStore.transformCoverage(coverageMap);

--- a/lib/run-reports.js
+++ b/lib/run-reports.js
@@ -34,17 +34,19 @@ function run(formats, config, opts, callback) {
     transformer = function (code, file) {
         return instrumenter.instrumentSync(code, file);
     };
-    opts.compilers.forEach(function (c) {
-        var compiler = c.split(':'),
-            ext = compiler[0],
-            mod = compiler[1];
+    if (opts.compilers) {
+        opts.compilers.forEach(function (c) {
+            var compiler = c.split(':'),
+                ext = compiler[0],
+                mod = compiler[1];
 
-        if (mod[0] === '.') {
-            mod = path.join(process.cwd(), mod);
-        }
-        compiledExtensions.push(ext);
-        require(mod);
-    });
+            if (mod[0] === '.') {
+                mod = path.join(process.cwd(), mod);
+            }
+            compiledExtensions.push(ext);
+            require(mod);
+        });
+    }
     if (compiledExtensions.length) {
         var hookOpts = {
             verbose: config.verbose,

--- a/lib/run-reports.js
+++ b/lib/run-reports.js
@@ -5,7 +5,11 @@
 var Reporter = require('./reporter'),
     fs = require('fs'),
     filesFor = require('./file-matcher').filesFor,
-    libCoverage = require('istanbul-lib-coverage');
+    libInstrument = require('istanbul-lib-instrument'),
+    libCoverage = require('istanbul-lib-coverage'),
+    libSourceMaps = require('istanbul-lib-source-maps'),
+    hook = require('istanbul-lib-hook'),
+    path = require('path');
 
 function run(formats, config, opts, callback) {
     if (!callback && typeof(opts) === 'function') {
@@ -15,8 +19,42 @@ function run(formats, config, opts, callback) {
     opts = opts || {};
     var root,
         coverageMap = libCoverage.createCoverageMap(),
+        sourceMapStore = libSourceMaps.createSourceMapStore({}),
+        instrumenter,
+        instOpts = config.instrumentation.getInstrumenterOpts(),
         includePattern = opts.include || '**/coverage*.raw.json',
-        reporter = new Reporter(config);
+        reporter = new Reporter(config),
+        transform,
+        compiledExtensions = [];
+
+    instOpts.sourceMapUrlCallback = function (file, url) {
+        sourceMapStore.registerURL(file, url);
+    };
+    instrumenter = libInstrument.createInstrumenter(instOpts);
+    transformer = function (code, file) {
+        return instrumenter.instrumentSync(code, file);
+    };
+    opts.compilers.forEach(function (c) {
+        var compiler = c.split(':')
+            , ext = compiler[0]
+            , mod = compiler[1];
+
+        if (mod[0] == '.') {
+            mod = join(process.cwd(), mod);
+        }
+        compiledExtensions.push(ext);
+        require(mod);
+    });
+    if (compiledExtensions.length) {
+        var hookOpts = {
+            verbose: config.verbose,
+            extensions: config.instrumentation.extensions()
+        };
+        hook.hookRequire(function matchFn(filePath) {
+            var ext = path.extname(filePath).substr(1);
+            return (compiledExtensions.indexOf(ext) !== -1);
+        }, transformer, hookOpts);
+    }
 
     if (!formats || formats.length === 0) {
         formats = config.reporting.reports();
@@ -41,7 +79,15 @@ function run(formats, config, opts, callback) {
             var coverageObject =  JSON.parse(fs.readFileSync(file, 'utf8'));
             coverageMap.merge(coverageObject);
         });
-        reporter.write(coverageMap, {});
+        if (compiledExtensions.length) {
+            for (var filepath in coverageMap.data) {
+                require(filepath);
+            }
+        }
+        var transformed = sourceMapStore.transformCoverage(coverageMap);
+        reporter.write(transformed.map, {
+            sourceFinder: transformed.sourceFinder
+        });
         return callback();
     });
 }


### PR DESCRIPTION
Hi,

I am setting up a typescript project : the tests file are compiled on the fly by our test frameworks (e.g.: for mocha we specify the **--compilers ts:ts-node/register** option).

When integrating istanbul to the project, I ran into an issue: the **cover** command works great, but when we run the **report** command (to merge multiple coverage.json files), it was creating a very strange report ...

I set up a [demo project here](https://github.com/rundef/typescript-istanbul-report)

This is the report the **cover** command generates :

![unit-coverage](https://cloud.githubusercontent.com/assets/2675698/16883470/1fdcd334-4a92-11e6-8148-259c1fab627f.png)

This is the report the **report** command generates :

![istanbul-report](https://cloud.githubusercontent.com/assets/2675698/16883490/4128a9be-4a92-11e6-814b-25ef1b14da4b.png)

After a little digging, I found out that this was happening because the source map URLs were not registered. To solve this issue, I added the --compilers option to the **report** command and I'm hooking into the **require** function (pretty much like it's done in **run-cover.js**)
