### PR TITLE
Bump fileset version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "async": "1.x",
-    "fileset": "0.2.x",
+    "fileset": "^2.0.2",
     "istanbul-lib-coverage": "^1.0.0-alpha",
     "istanbul-lib-hook": "^1.0.0-alpha",
     "istanbul-lib-instrument": "^1.1.0-alpha",

--- a/test/run-cover.test.js
+++ b/test/run-cover.test.js
@@ -122,7 +122,7 @@ describe('run cover', function () {
             assert.ok(coverageMap);
             assert.ok(coverageMap[path.resolve(codeRoot, 'context.js')]);
             assert.ok(coverageMap[path.resolve(codeRoot, 'foo.js')]);
-            assert.ok(coverageMap[path.resolve(codeRoot, 'node_modules', 'adder.js')]);
+            assert.ifError(coverageMap[path.resolve(codeRoot, 'node_modules', 'adder.js')]);
             cb();
         });
     });

--- a/test/run-instrument.test.js
+++ b/test/run-instrument.test.js
@@ -144,7 +144,7 @@ describe('run instrument', function () {
                 function (err) {
                     assert.ok(!err);
                     assert.ok(fs.existsSync(outFile('foo.js')));
-                    assert.ok(fs.existsSync(outFile('node_modules/adder.js')));
+                    assert.ok(!fs.existsSync(outFile('node_modules/adder.js')));
                     assert.ok(fs.existsSync(outFile('baseline.raw.json')));
                     cb();
                 });


### PR DESCRIPTION
The current fileset version use minimatch@2.0.10 which might cause a RegExp DoS issue.

Update fileset to the latest version fix this warning.

This will resolve #6 
