### PR TITLE
Updates the fileset version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "async": "1.x",
-    "fileset": "0.2.x",
+    "fileset": "^2.0.2",
     "istanbul-lib-coverage": "^1.0.0-alpha",
     "istanbul-lib-hook": "^1.0.0-alpha",
     "istanbul-lib-instrument": "^1.1.0-alpha",


### PR DESCRIPTION
The latest fileset version uses the latest minimatch version. This resolves the problem with npm warning:

```
minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```
