### PR TITLE
Fix test to use 0-indexed keys

### DIFF
--- a/test/run-cover.test.js
+++ b/test/run-cover.test.js
@@ -63,9 +63,9 @@ describe('run cover', function () {
             assert.ok(coverageMap);
             coverage = coverageMap[path.resolve(codeRoot, 'foo.js')];
             assert.ok(coverage);
-            assert.deepEqual(coverage.s, { 1:1, 2:0, 3:1, 4:1, 5:1 });
-            assert.deepEqual(coverage.f, { 1:1, 2: 0 });
-            assert.deepEqual(coverage.b, { 1: [1 ,0], 2: [1,0] });
+            assert.deepEqual(coverage.s, { 0:1, 1:0, 2:1, 3:1, 4:1 });
+            assert.deepEqual(coverage.f, { 0:1, 1:0 });
+            assert.deepEqual(coverage.b, { 0: [1 ,0], 1: [1,0] });
             exitFn();
             assert.ok(fs.existsSync(path.resolve(outputDir, 'coverage.raw.json')));
             assert.ok(fs.existsSync(path.resolve(outputDir, 'lcov.info')));


### PR DESCRIPTION
Tests are currently broken because the keys were updated to be 0-indexed, but the tests were not. This updates the tests to match the code.