### PR TITLE
Upgrade fileset dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "async": "1.x",
-    "fileset": "0.2.x",
+    "fileset": "2.x",
     "istanbul-lib-coverage": "^1.0.0-alpha",
     "istanbul-lib-hook": "^1.0.0-alpha",
     "istanbul-lib-instrument": "^1.1.0-alpha",


### PR DESCRIPTION
It's just the underlying glob/minimatch that's changed, except ignoring `node_modules` in sync

https://github.com/mklabs/node-fileset/compare/v0.2.1...v2.0.3